### PR TITLE
Fixes epicsarchiverap branch to clone from

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -42,7 +42,7 @@ FROM eclipse-temurin:17 AS build_archappl
 
 RUN apt-get update
 RUN apt-get install -y git python-is-python3 python3-pip python3-venv
-RUN git clone --branch configure_search_time https://github.com/ISISComputingGroup/epicsarchiverap /opt/aa-repo
+RUN git clone --branch master https://github.com/ISISComputingGroup/epicsarchiverap /opt/aa-repo
 WORKDIR /opt/aa-repo
 
 ENV ARCHAPPL_SITEID isis

--- a/Containerfile
+++ b/Containerfile
@@ -42,7 +42,7 @@ FROM eclipse-temurin:17 AS build_archappl
 
 RUN apt-get update
 RUN apt-get install -y git python-is-python3 python3-pip python3-venv
-RUN git clone --branch master https://github.com/ISISComputingGroup/epicsarchiverap /opt/aa-repo
+RUN git clone https://github.com/ISISComputingGroup/epicsarchiverap /opt/aa-repo
 WORKDIR /opt/aa-repo
 
 ENV ARCHAPPL_SITEID isis


### PR DESCRIPTION
Running `nerdctl compose -f docker-compose.yaml up` would cause various issues to occur as `configure_search_time` is no longer a branch and should instead point to master.