### PR TITLE
8520 iocdb tells aa which pvs to archive

### DIFF
--- a/iocdb_archive_sync/iocdb_archive_sync.py
+++ b/iocdb_archive_sync/iocdb_archive_sync.py
@@ -5,24 +5,27 @@ import asyncio
 import ast
 import os
 
-async def archivePV(url: str, session: aiohttp.ClientSession,) -> None:
+
+async def archivePV(url: str, session: aiohttp.ClientSession) -> None:
     response = await session.request("GET", url=url)
-    
+
     if response.status != 200:
         print(f"Could not archive: '{url}'.")
 
-async def main():
 
-    #should probably not hardcode this...
+async def main() -> None:
+    # should probably not hardcode this...
     iocdb = mysql.connector.connect(
         host="localhost",
         user=os.getenv("sql_iocdb_user"),
-        password=os.getenv("sql_iocdb_pass")
+        password=os.getenv("sql_iocdb_pass"),
     )
 
     ioccursor = iocdb.cursor()
 
-    ioccursor.execute("SELECT iocdb.pvinfo.pvname, iocdb.pvinfo.value from iocdb.pvinfo where infoname = 'archive' group by iocdb.pvinfo.pvname")
+    ioccursor.execute(
+        "SELECT iocdb.pvinfo.pvname, iocdb.pvinfo.value from iocdb.pvinfo where infoname = 'archive' group by iocdb.pvinfo.pvname"
+    )
 
     iocdb_pv_names = []
     iocdb_pv_value_types = []
@@ -39,20 +42,19 @@ async def main():
     archive_pv_names = ast.literal_eval(response.text)
 
     async with aiohttp.ClientSession() as session:
-
         tasks = []
 
         for pv in iocdb_pv_names:
-            
-            if pv in archive_pv_names: continue
+            if pv in archive_pv_names:
+                continue
 
             url = f"http://localhost:17665/mgmt/bpl/archivePV?pv={pv}"
-            tasks.append(archivePV(url=url,session=session))
+            tasks.append(archivePV(url=url, session=session))
 
         await asyncio.gather(*tasks, return_exceptions=True)
 
-if __name__ == '__main__':
-    
+
+if __name__ == "__main__":
     asyncio.run(main())
 
 # Next steps would be to make sure that any arguments that have been stored

--- a/iocdb_archive_sync/iocdb_archive_sync.py
+++ b/iocdb_archive_sync/iocdb_archive_sync.py
@@ -1,0 +1,61 @@
+import mysql.connector
+import aiohttp
+import requests
+import asyncio
+import ast
+import os
+
+async def archivePV(url: str, session: aiohttp.ClientSession,) -> None:
+    response = await session.request("GET", url=url)
+    
+    if response.status != 200:
+        print(f"Could not archive: '{url}'.")
+
+async def main():
+
+    #should probably not hardcode this...
+    iocdb = mysql.connector.connect(
+        host="localhost",
+        user=os.getenv("sql_iocdb_user"),
+        password=os.getenv("sql_iocdb_pass")
+    )
+
+    ioccursor = iocdb.cursor()
+
+    ioccursor.execute("SELECT iocdb.pvinfo.pvname, iocdb.pvinfo.value from iocdb.pvinfo where infoname = 'archive' group by iocdb.pvinfo.pvname")
+
+    iocdb_pv_names = []
+    iocdb_pv_value_types = []
+
+    for result in ioccursor.fetchall():
+        iocdb_pv_names.append(result[0])
+        iocdb_pv_value_types.append(result[1])
+
+    # The API endpoint
+    url = "http://localhost:17665/mgmt/bpl/getAllPVs"
+
+    # A GET request to the API
+    response = requests.get(url)
+    archive_pv_names = ast.literal_eval(response.text)
+
+    async with aiohttp.ClientSession() as session:
+
+        tasks = []
+
+        for pv in iocdb_pv_names:
+            
+            if pv in archive_pv_names: continue
+
+            url = f"http://localhost:17665/mgmt/bpl/archivePV?pv={pv}"
+            tasks.append(archivePV(url=url,session=session))
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+if __name__ == '__main__':
+    
+    asyncio.run(main())
+
+# Next steps would be to make sure that any arguments that have been stored
+# alongside val in iocdb get passed to archivePV in the appropriate ways
+# e.g sample rate
+# print(iocdb_pv_value_types) to see different stored args + value


### PR DESCRIPTION
This is a proof of concept that PVs which are marked as `archive` in iocdb, can be discovered by a python script and checked if they are being archived by the archive appliance, if not then a http requests are sent asynchronously per PV to start archiving them. Further work will be required, mainly that in the iocdb value field, there can be more than just `VAL` and arguments regarding how the PV is stored is put alongside `VAL`- the python script would have to extract these arguments and place them in the http request so that the PV is being archived as requested. As of writing we are putting development with the archive appliance on hold- this may get picked up again later down the line.